### PR TITLE
Get rid of warning for deps in Elixir 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: elixir
+elixir:
+  - 1.3.4
 script: make

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Kata.Mixfile do
     [app: :kata,
      version: "0.0.1",
      elixir: "~> 1.0",
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Get rid of this warning in Elixir 1.5

`warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:8`